### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,11 +19,11 @@ I maintain "a list of apps using ios-calendar":https://github.com/vgrichina/ios-
 h2. Project setup
 
 While not elegant at all, currently the best method to add ios-calendar to your project is just to drop its source code in it (from "Calendar" group).
-It is possible to use it as dependency, but only when your project doesn't itself use Three20. Otherwise build results in XCode crash. I'm looking for suggestions on how better to resolve this issue.
+It is possible to use it as dependency, but only when your project doesn't itself use Three20. Otherwise build results in Xcode crash. I'm looking for suggestions on how better to resolve this issue.
 
 h2. Usage sample
 
-XCode project on GitHub contains sample target - CalendarDemo. Here are main highlights:
+Xcode project on GitHub contains sample target - CalendarDemo. Here are main highlights:
 
 h3. CalendarDemoViewController.m
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
